### PR TITLE
add two functions to verify proof without ctx

### DIFF
--- a/librustzcash/include/librustzcash.h
+++ b/librustzcash/include/librustzcash.h
@@ -167,6 +167,27 @@ extern "C" {
         const unsigned char *sighashValue
     );
 
+    /// Check the validity of a Sapling Spend description
+    /// This function is only called by specific contract
+    bool librustzcash_sapling_check_spend_new(
+            const unsigned char *cv,
+            const unsigned char *anchor,
+            const unsigned char *nullifier,
+            const unsigned char *rk,
+            const unsigned char *zkproof,
+            const unsigned char *spendAuthSig,
+            const unsigned char *sighashValue
+    );
+
+    /// Check the validity of a Sapling Output description,
+    /// This function is only called by specific contract
+    bool librustzcash_sapling_check_output_new(
+            const unsigned char *cv,
+            const unsigned char *cm,
+            const unsigned char *ephemeralKey,
+            const unsigned char *zkproof
+    );
+
     /// Finally checks the validity of the entire Sapling
     /// transaction given valueBalance and the binding signature.
     /// This function is only called by specific contract


### PR DESCRIPTION
What does this PR do?
Add two functions to verify proof without ctx.

Why are these changes required?
It is necessary to be used in precompiled contract in order to avoid unpredictable problems in multithreaded calls.

This PR has been tested by:
Unit Tests
Manual Tests